### PR TITLE
chore: dockerize bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.1-alpine
+FROM python:3.13-alpine
 
 RUN apk --no-cache add ffmpeg opus
 
@@ -8,4 +8,3 @@ COPY . .
 RUN pip install -r requirements.txt
 
 CMD ["python", "-OO", "main.py"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 
 RUN pip install -r requirements.txt
 
-CMD ["python", "main.py"]
+CMD ["python", "-OO", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.13.1-alpine
+
+WORKDIR /bot
+COPY . .
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13.1-alpine
 
-RUN apk --no-cache add ffmpeg
+RUN apk --no-cache add ffmpeg opus
 
 WORKDIR /bot
 COPY . .
@@ -8,3 +8,4 @@ COPY . .
 RUN pip install -r requirements.txt
 
 CMD ["python", "-OO", "main.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13.1-alpine
 
+RUN apk --no-cache add ffmpeg
+
 WORKDIR /bot
 COPY . .
 


### PR DESCRIPTION
Created Dockerfile based on a python docker image (python 3.13.1 on alpine):
- copies all the files in the image
- installs the dependencies
- runs the bot

## Usage
> [!NOTE]
> Fedora users can just replace the `docker` command with `podman`, since it's already installed

### Build
```shell
docker build . --tag errornocord-bot:$VERSION
```

### Run
```shell
docker run errornocord-bot:$VERSION
```

I cannot test because I lack the token but I think it should work fine, or at least it should start fine, since the only error it outputs is the missing token.
